### PR TITLE
Allow for custom protocols

### DIFF
--- a/src/syslog_lib.erl
+++ b/src/syslog_lib.erl
@@ -159,7 +159,7 @@ truncate(L, S) when is_binary(S)   -> binary:part(S, 0, L).
 
 %%------------------------------------------------------------------------------
 %% @doc
-%% Returns a truncated string.
+%% Returns a formated timestamp for the syslog datetime object (UTC).
 %% @end
 %%------------------------------------------------------------------------------
 -spec get_date(syslog:datetime()) -> list().

--- a/src/syslog_lib.erl
+++ b/src/syslog_lib.erl
@@ -27,7 +27,9 @@
          get_property/2,
          get_pid/1,
          get_utc_datetime/1,
-         get_utc_offset/2]).
+         get_utc_offset/2,
+         truncate/2,
+         get_date/1]).
 
 -define(GET_ENV(Property), application:get_env(syslog, Property)).
 
@@ -142,6 +144,38 @@ get_utc_offset(Utc, Local) ->
     {0, {H, Mi, 0}} = time_difference(Local, Utc),
     {$-, H, Mi}.
 
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Returns a truncated string.
+%% @end
+%%------------------------------------------------------------------------------
+-spec truncate(pos_integer(), string() | binary()) -> string() | binary().
+
+truncate(L, S) when length(S) =< L -> S;
+truncate(L, S) when size(S) =< L   -> S;
+truncate(L, S) when is_list(S)     -> string:substr(S, 1, L);
+truncate(L, S) when is_binary(S)   -> binary:part(S, 0, L).
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Returns a truncated string.
+%% @end
+%%------------------------------------------------------------------------------
+-spec get_date(syslog:datetime()) -> list().
+
+get_date({UtcDatetime, MicroSecs}) ->
+    LocaDatetime = erlang:universaltime_to_localtime(UtcDatetime),
+    get_date(LocaDatetime, UtcDatetime, MicroSecs).
+get_date(Utc = {{Y, Mo, D}, {H, Mi, S}}, Utc, Micro) ->
+    [integer_to_list(Y), $-, digit(Mo), $-, digit(D), $T,
+     digit(H), $:, digit(Mi), $:, digit(S), $., micro(Micro), $Z];
+get_date(Local = {{Y, Mo, D}, {H, Mi, S}}, Utc, Micro) ->
+    {Sign, OH, OMi} = syslog_lib:get_utc_offset(Utc, Local),
+    [integer_to_list(Y), $-, digit(Mo), $-, digit(D), $T,
+     digit(H), $:, digit(Mi), $:, digit(S), $., micro(Micro),
+     Sign, digit(OH), $:, digit(OMi)].
+
 %%%=============================================================================
 %%% internal functions
 %%%=============================================================================
@@ -206,6 +240,31 @@ time_difference(T1, T2) ->
       calendar:datetime_to_gregorian_seconds(T2) -
           calendar:datetime_to_gregorian_seconds(T1)).
 
+%%------------------------------------------------------------------------------
+%% @private
+%%------------------------------------------------------------------------------
+digit(0)  -> "00";
+digit(1)  -> "01";
+digit(2)  -> "02";
+digit(3)  -> "03";
+digit(4)  -> "04";
+digit(5)  -> "05";
+digit(6)  -> "06";
+digit(7)  -> "07";
+digit(8)  -> "08";
+digit(9)  -> "09";
+digit(N)  -> integer_to_list(N).
+
+%%------------------------------------------------------------------------------
+%% @private
+%%------------------------------------------------------------------------------
+micro(M) when M < 10     -> ["00000", integer_to_list(M)];
+micro(M) when M < 100    -> ["0000", integer_to_list(M)];
+micro(M) when M < 1000   -> ["000", integer_to_list(M)];
+micro(M) when M < 10000  -> ["00", integer_to_list(M)];
+micro(M) when M < 100000 -> ["0", integer_to_list(M)];
+micro(M)                 -> integer_to_list(M).
+
 %%%=============================================================================
 %%% TESTS
 %%%=============================================================================
@@ -237,5 +296,26 @@ get_pid_test() ->
     ?assertEqual(<<"init">>, get_pid(init)),
     ?assertEqual(<<"init">>, get_pid(whereis(init))),
     ?assertEqual(list_to_binary(pid_to_list(self())), get_pid(self())).
+
+truncate_test() ->
+    ?assertEqual("",        truncate(0, "")),
+    ?assertEqual("",        truncate(1, "")),
+    ?assertEqual("",        truncate(0, "123")),
+    ?assertEqual("1",       truncate(1, "123")),
+    ?assertEqual("12",      truncate(2, "123")),
+    ?assertEqual("123",     truncate(3, "123")),
+    ?assertEqual("123",     truncate(4, "123")),
+    ?assertEqual(<<>>,      truncate(0, <<>>)),
+    ?assertEqual(<<>>,      truncate(1, <<>>)),
+    ?assertEqual(<<>>,      truncate(0, <<"123">>)),
+    ?assertEqual(<<"1">>,   truncate(1, <<"123">>)),
+    ?assertEqual(<<"12">>,  truncate(2, <<"123">>)),
+    ?assertEqual(<<"123">>, truncate(3, <<"123">>)),
+    ?assertEqual(<<"123">>, truncate(4, <<"123">>)).
+
+get_date_test() ->
+    Datetime = {{{2013,4,6},{21,20,56}},908235},
+    Rx = "2013-04-06T\\d\\d:\\d\\d:56\\.908235(Z|(\\+|-)\\d\\d:\\d\\d)",
+    ?assertMatch({match, _}, re:run(lists:flatten(get_date(Datetime)), Rx)).
 
 -endif. %% TEST

--- a/src/syslog_logger.erl
+++ b/src/syslog_logger.erl
@@ -422,7 +422,8 @@ map_facility(local7)   -> 23.
 get_protocol({P, _, _}) when is_atom(P) -> get_protocol(P);
 get_protocol({P, _}) when is_atom(P)    -> get_protocol(P);
 get_protocol(rfc5424)                   -> syslog_rfc5424;
-get_protocol(rfc3164)                   -> syslog_rfc3164.
+get_protocol(rfc3164)                   -> syslog_rfc3164;
+get_protocol(P)                         -> P.
 
 %%------------------------------------------------------------------------------
 %% @private

--- a/src/syslog_rfc5424.erl
+++ b/src/syslog_rfc5424.erl
@@ -23,7 +23,7 @@
 -behaviour(syslog_logger).
 
 %% API
--export([hdr/3, msg/2, get_date/1, truncate/2]).
+-export([hdr/3, msg/2]).
 
 -include("syslog.hrl").
 
@@ -43,11 +43,11 @@
 hdr(Datetime, Pid, #syslog_cfg{hostname = H, appname = A, beam_pid = B}) ->
     [
      ?VERSION, $\s,
-     get_date(Datetime), $\s,
-     truncate(255, H), $\s,
-     truncate(48, A), $\s,
-     truncate(128, B), $\s,
-     truncate(32, Pid), $\s, $-, $\s
+     syslog_lib:get_date(Datetime), $\s,
+     syslog_lib:truncate(255, H), $\s,
+     syslog_lib:truncate(48, A), $\s,
+     syslog_lib:truncate(128, B), $\s,
+     syslog_lib:truncate(32, Pid), $\s, $-, $\s
     ].
 
 %%------------------------------------------------------------------------------
@@ -59,85 +59,3 @@ hdr(Datetime, Pid, #syslog_cfg{hostname = H, appname = A, beam_pid = B}) ->
 msg(Msg, #syslog_cfg{bom = Bom}) ->
     unicode:characters_to_binary([Bom, Msg]).
 
-%%%=============================================================================
-%%% internal functions
-%%%=============================================================================
-
-%%------------------------------------------------------------------------------
-%% @private
-%%------------------------------------------------------------------------------
-get_date({UtcDatetime, MicroSecs}) ->
-    LocaDatetime = erlang:universaltime_to_localtime(UtcDatetime),
-    get_date(LocaDatetime, UtcDatetime, MicroSecs).
-get_date(Utc = {{Y, Mo, D}, {H, Mi, S}}, Utc, Micro) ->
-    [integer_to_list(Y), $-, digit(Mo), $-, digit(D), $T,
-     digit(H), $:, digit(Mi), $:, digit(S), $., micro(Micro), $Z];
-get_date(Local = {{Y, Mo, D}, {H, Mi, S}}, Utc, Micro) ->
-    {Sign, OH, OMi} = syslog_lib:get_utc_offset(Utc, Local),
-    [integer_to_list(Y), $-, digit(Mo), $-, digit(D), $T,
-     digit(H), $:, digit(Mi), $:, digit(S), $., micro(Micro),
-     Sign, digit(OH), $:, digit(OMi)].
-
-%%------------------------------------------------------------------------------
-%% @private
-%%------------------------------------------------------------------------------
-digit(0)  -> "00";
-digit(1)  -> "01";
-digit(2)  -> "02";
-digit(3)  -> "03";
-digit(4)  -> "04";
-digit(5)  -> "05";
-digit(6)  -> "06";
-digit(7)  -> "07";
-digit(8)  -> "08";
-digit(9)  -> "09";
-digit(N)  -> integer_to_list(N).
-
-%%------------------------------------------------------------------------------
-%% @private
-%%------------------------------------------------------------------------------
-micro(M) when M < 10     -> ["00000", integer_to_list(M)];
-micro(M) when M < 100    -> ["0000", integer_to_list(M)];
-micro(M) when M < 1000   -> ["000", integer_to_list(M)];
-micro(M) when M < 10000  -> ["00", integer_to_list(M)];
-micro(M) when M < 100000 -> ["0", integer_to_list(M)];
-micro(M)                 -> integer_to_list(M).
-
-%%------------------------------------------------------------------------------
-%% @private
-%%------------------------------------------------------------------------------
-truncate(L, S) when length(S) =< L -> S;
-truncate(L, S) when size(S) =< L   -> S;
-truncate(L, S) when is_list(S)     -> string:substr(S, 1, L);
-truncate(L, S) when is_binary(S)   -> binary:part(S, 0, L).
-
-%%%=============================================================================
-%%% Tests
-%%%=============================================================================
-
--ifdef(TEST).
-
--include_lib("eunit/include/eunit.hrl").
-
-get_date_test() ->
-    Datetime = {{{2013,4,6},{21,20,56}},908235},
-    Rx = "2013-04-06T\\d\\d:\\d\\d:56\\.908235(Z|(\\+|-)\\d\\d:\\d\\d)",
-    ?assertMatch({match, _}, re:run(lists:flatten(get_date(Datetime)), Rx)).
-
-truncate_test() ->
-    ?assertEqual("",        truncate(0, "")),
-    ?assertEqual("",        truncate(1, "")),
-    ?assertEqual("",        truncate(0, "123")),
-    ?assertEqual("1",       truncate(1, "123")),
-    ?assertEqual("12",      truncate(2, "123")),
-    ?assertEqual("123",     truncate(3, "123")),
-    ?assertEqual("123",     truncate(4, "123")),
-    ?assertEqual(<<>>,      truncate(0, <<>>)),
-    ?assertEqual(<<>>,      truncate(1, <<>>)),
-    ?assertEqual(<<>>,      truncate(0, <<"123">>)),
-    ?assertEqual(<<"1">>,   truncate(1, <<"123">>)),
-    ?assertEqual(<<"12">>,  truncate(2, <<"123">>)),
-    ?assertEqual(<<"123">>, truncate(3, <<"123">>)),
-    ?assertEqual(<<"123">>, truncate(4, <<"123">>)).
-
--endif.

--- a/src/syslog_rfc5424.erl
+++ b/src/syslog_rfc5424.erl
@@ -23,7 +23,7 @@
 -behaviour(syslog_logger).
 
 %% API
--export([hdr/3, msg/2]).
+-export([hdr/3, msg/2, get_date/1, truncate/2]).
 
 -include("syslog.hrl").
 


### PR DESCRIPTION
This allows for configuring custom protocol modules that implement the `syslog_logger` bevahiour.

The second change, exporting some utility functions from syslog_rfc5424, is arguable. I found it handy but, I'm happy to change it around.