### PR TITLE
Use no_format by default

### DIFF
--- a/src/syslog.erl
+++ b/src/syslog.erl
@@ -88,7 +88,7 @@
 %% @end
 %%------------------------------------------------------------------------------
 -spec debug_msg(io:format()) -> ok.
-debug_msg(Msg) -> debug_msg(Msg, no_format).
+debug_msg(Msg) -> debug_msg(Msg, []).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -105,7 +105,7 @@ debug_msg(Fmt, Args) -> msg(debug, Fmt, Args).
 %% @end
 %%------------------------------------------------------------------------------
 -spec info_msg(io:format()) -> ok.
-info_msg(Msg) -> info_msg(Msg, no_format).
+info_msg(Msg) -> info_msg(Msg, []).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -123,7 +123,7 @@ info_msg(Fmt, Args) -> msg(informational, Fmt, Args).
 %% @end
 %%------------------------------------------------------------------------------
 -spec warning_msg(io:format()) -> ok.
-warning_msg(Msg) -> warning_msg(Msg, no_format).
+warning_msg(Msg) -> warning_msg(Msg, []).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -141,7 +141,7 @@ warning_msg(Fmt, Args) -> msg(warning, Fmt, Args).
 %% @end
 %%------------------------------------------------------------------------------
 -spec error_msg(io:format()) -> ok.
-error_msg(Msg) -> error_msg(Msg, no_format).
+error_msg(Msg) -> error_msg(Msg, []).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -158,7 +158,7 @@ error_msg(Fmt, Args) -> msg(error, Fmt, Args).
 %% @end
 %%------------------------------------------------------------------------------
 -spec msg(severity(), io:format()) -> ok.
-msg(Severity, Msg) -> msg(Severity, Msg, no_format).
+msg(Severity, Msg) -> msg(Severity, Msg, []).
 
 %%------------------------------------------------------------------------------
 %% @doc

--- a/src/syslog.erl
+++ b/src/syslog.erl
@@ -88,14 +88,14 @@
 %% @end
 %%------------------------------------------------------------------------------
 -spec debug_msg(io:format()) -> ok.
-debug_msg(Msg) -> debug_msg(Msg, []).
+debug_msg(Msg) -> debug_msg(Msg, no_format).
 
 %%------------------------------------------------------------------------------
 %% @doc
 %% Sends a format message with severity `debug'. This function never fails.
 %% @end
 %%------------------------------------------------------------------------------
--spec debug_msg(io:format(), [term()]) -> ok.
+-spec debug_msg(io:format(), [term()] | no_format) -> ok.
 debug_msg(Fmt, Args) -> msg(debug, Fmt, Args).
 
 %%------------------------------------------------------------------------------
@@ -105,7 +105,7 @@ debug_msg(Fmt, Args) -> msg(debug, Fmt, Args).
 %% @end
 %%------------------------------------------------------------------------------
 -spec info_msg(io:format()) -> ok.
-info_msg(Msg) -> info_msg(Msg, []).
+info_msg(Msg) -> info_msg(Msg, no_format).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -113,7 +113,7 @@ info_msg(Msg) -> info_msg(Msg, []).
 %% counterpart this function never fails.
 %% @end
 %%------------------------------------------------------------------------------
--spec info_msg(io:format(), [term()]) -> ok.
+-spec info_msg(io:format(), [term()] | no_format) -> ok.
 info_msg(Fmt, Args) -> msg(informational, Fmt, Args).
 
 %%------------------------------------------------------------------------------
@@ -123,7 +123,7 @@ info_msg(Fmt, Args) -> msg(informational, Fmt, Args).
 %% @end
 %%------------------------------------------------------------------------------
 -spec warning_msg(io:format()) -> ok.
-warning_msg(Msg) -> warning_msg(Msg, []).
+warning_msg(Msg) -> warning_msg(Msg, no_format).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -131,7 +131,7 @@ warning_msg(Msg) -> warning_msg(Msg, []).
 %% counterpart this function never fails.
 %% @end
 %%------------------------------------------------------------------------------
--spec warning_msg(io:format(), [term()]) -> ok.
+-spec warning_msg(io:format(), [term()] | no_format) -> ok.
 warning_msg(Fmt, Args) -> msg(warning, Fmt, Args).
 
 %%------------------------------------------------------------------------------
@@ -141,7 +141,7 @@ warning_msg(Fmt, Args) -> msg(warning, Fmt, Args).
 %% @end
 %%------------------------------------------------------------------------------
 -spec error_msg(io:format()) -> ok.
-error_msg(Msg) -> error_msg(Msg, []).
+error_msg(Msg) -> error_msg(Msg, no_format).
 
 %%------------------------------------------------------------------------------
 %% @doc
@@ -149,7 +149,7 @@ error_msg(Msg) -> error_msg(Msg, []).
 %% counterpart this function never fails.
 %% @end
 %%------------------------------------------------------------------------------
--spec error_msg(io:format(), [term()]) -> ok.
+-spec error_msg(io:format(), [term()] | no_format) -> ok.
 error_msg(Fmt, Args) -> msg(error, Fmt, Args).
 
 %%------------------------------------------------------------------------------
@@ -158,14 +158,14 @@ error_msg(Fmt, Args) -> msg(error, Fmt, Args).
 %% @end
 %%------------------------------------------------------------------------------
 -spec msg(severity(), io:format()) -> ok.
-msg(Severity, Msg) -> msg(Severity, Msg, []).
+msg(Severity, Msg) -> msg(Severity, Msg, no_format).
 
 %%------------------------------------------------------------------------------
 %% @doc
 %% Logs a format message with a specific severity. This function never fails.
 %% @end
 %%------------------------------------------------------------------------------
--spec msg(severity(), io:format(), [term()]) -> ok.
+-spec msg(severity(), io:format(), [term()] | no_format) -> ok.
 msg(Severity, Fmt, Args) -> msg(Severity, self(), Fmt, Args).
 
 %%------------------------------------------------------------------------------
@@ -174,7 +174,7 @@ msg(Severity, Fmt, Args) -> msg(Severity, self(), Fmt, Args).
 %% function never fails.
 %% @end
 %%------------------------------------------------------------------------------
--spec msg(severity(), proc_name(), io:format(), [term()]) -> ok.
+-spec msg(severity(), proc_name(), io:format(), [term()] | no_format) -> ok.
 msg(Severity, Pid, Fmt, Args) ->
     msg(Severity, Pid, [], Fmt, Args).
 
@@ -186,7 +186,11 @@ msg(Severity, Pid, Fmt, Args) ->
 %% This function never fails.
 %% @end
 %%------------------------------------------------------------------------------
--spec msg(severity(), proc_name(), [sd_element()], io:format(), [term()]) -> ok.
+-spec msg(severity(),
+          proc_name(),
+          [sd_element()],
+          io:format(),
+          [term()] | no_format) -> ok.
 msg(Severity, Pid, SD, Fmt, Args) ->
     syslog_logger:log(Severity, Pid, os:timestamp(), SD, Fmt, Args).
 


### PR DESCRIPTION
`syslog_logger:maybe_log/7` has a case statement which can skips formatting the message when you supply the `no_format` atom to the `*_msg/2` logging functions as the Args. However this isn't made use of by the `*_msg/1` functions which by default pass an empty list and then `maybe_log` will try and format the message when it doesn't have to.

This pull makes two changes:
 * Make all the `*_msg/1` function pass `no_format` instead of an empty list for improved performance.
 * Add `no_format` to the spec for all `*_msg/2` functions