### PR TITLE
Support string pids in lager metadata.

### DIFF
--- a/src/syslog_lager_backend.erl
+++ b/src/syslog_lager_backend.erl
@@ -171,8 +171,9 @@ get_pid(Msg) ->
     try apply(lager_msg, metadata, [Msg]) of
         Metadata ->
             case lists:keyfind(pid, 1, Metadata) of
-                {pid, Pid} when is_pid(Pid) -> Pid;
-                _                           -> self()
+                {pid, Pid} when is_pid(Pid)    -> Pid;
+                {pid, List} when is_list(List) -> List;
+                _                              -> self()
             end
     catch
         _:_ -> self()


### PR DESCRIPTION
Lager parse-transform adds pid as string by default.
This makes all parse-transformed log messages display
`lager_event` as a pid, which is not correct.
Converting a pid from string is not always safe,
but syslog_logger can work with strings.