### PR TITLE
Support formatter of {handler, syslog, syslog_logger_h, #{formatter =…

### DIFF
--- a/src/syslog_logger_h.erl
+++ b/src/syslog_logger_h.erl
@@ -259,7 +259,8 @@ verify_cfg(Cfg) when is_map(Cfg) ->
     Cfg2 = maps_put_if_not_present(filters, Filters, Cfg1),
 
     FormatterCfg = syslog_lib:get_property(formatter_cfg, ?FORMATTER_CFG),
-    {ok, maps:put(formatter, {logger_formatter, FormatterCfg}, Cfg2)};
+    Formatter = maps:get(formatter, Cfg2, {logger_formatter, FormatterCfg}),
+    {ok, maps:put(formatter, Formatter, Cfg2)};
 verify_cfg(Cfg) ->
     {error, {invalid_config, Cfg}}.
 


### PR DESCRIPTION
In the following `sys.config`, using a different formatter (like [flatlog](https://github.com/ferd/flatlog)) does not take effect.
```
                {syslog, [
                    {logger, [{handler, syslog, syslog_logger_h, #{
                        formatter => {flatlog, #{
                            map_depth => 3,
                            term_depth => 50
                        }}
                    }}]},
                    {dest_port, 12345},
                    {dest_host, "logs.somewhere.com"},
                    {protocol, rfc5424}
                ]}
```
It is because there is code in the `syslog_logger_h:verify_cfg` function that overwrites with this formatter `#{single_line => false, template => [msg]}` instead.

This PR will allow a custom formatter to be set and make the above `sys.config` work.