### PR TITLE
More correct no_progress filter apply...

### DIFF
--- a/src/syslog_logger_h.erl
+++ b/src/syslog_logger_h.erl
@@ -257,7 +257,7 @@ verify_cfg(Cfg) when is_map(Cfg) ->
     NoProgress = syslog_lib:get_property(no_progress, ?SYSLOG_NO_PROGRESS),
     ProgressAction = case NoProgress of true -> stop; false -> log end,
     Filters = [{progress, {fun logger_filters:progress/2, ProgressAction}}],
-    Cfg2 = maps_put_if_not_present(filters, Filters, Cfg1),
+    Cfg2 = maps_put_into_filters_if_not_present(filters, Filters, Cfg1),
 
     {ok, case maps:find(formatter, Cfg2) of
              error ->
@@ -287,4 +287,17 @@ maps_put_if_not_present(Key, Value, Map) ->
     case maps:find(Key, Map) of
         {ok, _} -> Map;
         error   -> maps:put(Key, Value, Map)
+    end.
+
+maps_put_into_filters_if_not_present(Key, Value, Map) ->
+    case maps:find(Key, Map) of
+        {ok, Filters} ->
+            case lists:keyfind(progress, 1, Filters) of
+                false ->
+                    maps:put(Key, Filters ++ Value, Map);
+                _ ->
+                    Map
+            end;
+        error ->
+            maps:put(Key, Value, Map)
     end.


### PR DESCRIPTION
Now  `logger:get_config()` returns:

```
1> logger:get_config().
#{handlers =>
      [#{config =>
             #{appname_key => undefined,extra_report => true,
               structured_data => []},
         filter_default => stop,
         filters =>
             [{remote_gl,{fun logger_filters:remote_gl/2,stop}},
              {domain,{fun logger_filters:domain/2,{log,super,[otp]}}},
              {no_domain,{fun logger_filters:domain/2,{log,undefined,[]}}}],

```
even in sys.config I'm specify `{no_progress, true}`...