### PR TITLE
Fix lost millisecond precision

### DIFF
--- a/src/syslog_lib.erl
+++ b/src/syslog_lib.erl
@@ -167,7 +167,7 @@ get_pid(N) ->
 -spec get_utc_datetime(erlang:timestamp() | pos_integer()) -> syslog:datetime().
 get_utc_datetime(SystemTime) when is_integer(SystemTime), SystemTime > 0 ->
     MilliSecs = SystemTime div 1000,
-    MicroSecs = SystemTime rem 1000,
+    MicroSecs = SystemTime rem 1000000,
     Datetime = calendar:system_time_to_universal_time(MilliSecs, millisecond),
     {Datetime, MicroSecs};
 get_utc_datetime({MegaSecs, Secs, MicroSecs}) ->


### PR DESCRIPTION
Before:
2020-04-13T10:34:22.000766Z r01.aaa.ru WARNING aaa[4685]
2020-04-13T10:34:22.000984Z r01.aaa.ru WARNING aaa[4685]
2020-04-13T10:34:23.000220Z r01.aaa.ru WARNING aaa[4685]
2020-04-13T10:34:23.000430Z r01.aaa.ru WARNING aaa[4685]
2020-04-13T10:34:23.000774Z r01.aaa.ru WARNING aaa[4685]
2020-04-13T10:34:23.000852Z r01.aaa.ru WARNING aaa[4685]

After:
2020-04-13T12:46:28.504894Z r01.aaa.ru NOTICE hbr[28998]
2020-04-13T12:46:28.506583Z r01.aaa.ru NOTICE hbr[28998]
2020-04-13T12:46:28.506583Z r01.aaa.ru NOTICE hbr[28998]
2020-04-13T12:46:28.506583Z r01.aaa.ru NOTICE hbr[28998]