### PR TITLE
Fix logger formatter configuration

### DIFF
--- a/src/syslog_logger_h.erl
+++ b/src/syslog_logger_h.erl
@@ -267,7 +267,8 @@ verify_cfg(Cfg) when is_map(Cfg) ->
     {ok, case maps:find(formatter, Cfg2) of
              error ->
                  maps:put(formatter, ?FORMATTER, Cfg2);
-             {ok, {logger_formatter, #{}}} -> %% the OTP default
+             {ok, {logger_formatter, FormatterCfg}}
+               when map_size(FormatterCfg) =:= 0 -> %% the OTP default
                  maps:put(formatter, ?FORMATTER, Cfg2);
              {ok, _} ->
                  Cfg2


### PR DESCRIPTION
syslog_logger_h has its own default formatter configuration that should
be preferred over OTP defaults.  To properly detect OTP defaults we
should compare formatter configuration with empty map.